### PR TITLE
Added checker for dir and changed the .contains call

### DIFF
--- a/watson-vr-java-tester/src/main/java/com/ibm/demo/WatsonVRTester.java
+++ b/watson-vr-java-tester/src/main/java/com/ibm/demo/WatsonVRTester.java
@@ -68,6 +68,10 @@ public class WatsonVRTester {
 		// Get all jog files in test image folder
 		File dir = new File(properties.getProperty("TEST_IMAGE_DIR"));
 		String[] extensions = new String[] { "jpg" };
+		
+		if (!dir.isDirectory()) {
+			dir = new File(properties.getProperty("TEST_DATA_DIR").replaceAll("\\.\\.", ""));
+		}
 
 		List<File> files = (List<File>) FileUtils.listFiles(dir, extensions, true);
 
@@ -83,7 +87,7 @@ public class WatsonVRTester {
 			List<ClassResult> classes = classifier.getClasses();
 			
 			// Handle test images that are not wedding photos
-			if (file.getCanonicalPath().contains("/notwedding/")) {
+			if (file.getCanonicalPath().contains("notwedding")) {
 				// true negative because it isn't a wedding photo and classifier thinks it isn't
 				// one too
 				if (classes.isEmpty()) {


### PR DESCRIPTION
This checker should be able to check to see if the dir variable (../test_data) contains files, if not, alter the variable (/test_data) and try again. This should account for both Eclipse and IntelliJ environments